### PR TITLE
Add Alert Component

### DIFF
--- a/apps/views/components/alert-box/AlertBox.js
+++ b/apps/views/components/alert-box/AlertBox.js
@@ -1,0 +1,40 @@
+import PropTypes from "prop-types";
+
+import stl from "./AlertBox.module.css";
+
+const AlertBox = ({ varient, label, children }) => {
+  const close = true;
+
+  return (
+    <div
+      className={`alert alert-${varient} ${
+        close && "alert-dismissible fade show"
+      } ${stl.alertBox}`}
+      role="alert"
+    >
+      {children ? children : <p>{label}</p>}
+      {close && (
+        <button
+          type="button"
+          className={`close ${stl.closeButton}`}
+          data-dismiss="alert"
+          aria-label="Close"
+        >
+          <span aria-hidden="false">&times;</span>
+        </button>
+      )}
+    </div>
+  );
+};
+
+AlertBox.defaultProps = {
+  varient: "primary",
+};
+
+AlertBox.propTypes = {
+  varient: PropTypes.string.isRequired,
+  label: PropTypes.string,
+  children: PropTypes.node,
+};
+
+export default AlertBox;

--- a/apps/views/components/alert-box/AlertBox.module.css
+++ b/apps/views/components/alert-box/AlertBox.module.css
@@ -1,0 +1,43 @@
+@import "styles/common";
+
+.alertBox {
+  opacity: 0;
+  animation: blowUp 0.2s ease-in forwards;
+  position: relative;
+}
+
+.alertBox p {
+  margin: 0;
+}
+
+.alertBox a {
+  text-decoration: underline;
+  color: inherit;
+}
+
+.closeButton {
+  all: unset;
+  position: absolute;
+  top: 5.5px;
+  right: 0;
+  padding: 0 1rem;
+  font-size: 28px;
+  font-weight: 500;
+  color: inherit;
+  opacity: 0.4;
+}
+
+.closeButton:hover {
+  opacity: 1;
+}
+
+@keyframes blowUp {
+  0% {
+    transform: scale(0);
+    opacity: 0;
+  }
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+}

--- a/apps/views/components/alert-box/index.js
+++ b/apps/views/components/alert-box/index.js
@@ -1,0 +1,3 @@
+import AlertBox from "./AlertBox";
+
+export default AlertBox;

--- a/apps/views/pages/alert_box.tsx
+++ b/apps/views/pages/alert_box.tsx
@@ -1,0 +1,40 @@
+import Link from "next/link";
+
+import AlertBox from "components/alert-box/index";
+
+const Alert = () => {
+  return (
+    <div className="container my-5">
+      <AlertBox varient="primary" label="Custom message" />
+      <AlertBox varient="danger">
+        <h4>Alert!</h4>
+        <p>
+          I'm here by using children of Alert component. Aww yeah, you
+          successfully read this important alert message. This example text is
+          going to run a bit longer so that you can see how spacing within an
+          alert works with this kind of content.
+        </p>
+        <hr />
+        <p>{`You can use <hr /> tag in Alert component simply.`}</p>
+      </AlertBox>
+      <AlertBox varient="info">
+        <p>
+          You can use <Link href="#">example link(s)</Link> in alert box simply.
+        </p>
+      </AlertBox>
+      <AlertBox
+        varient="secondary"
+        label="An error occured while displaying previous error."
+      />
+      <AlertBox varient="success">
+        <strong>Be bold!</strong>{" "}
+        {`You can simply use <strong></strong> tag in Alert Component.`}
+      </AlertBox>
+      <AlertBox varient="warning" label="I'm from warning alert!" />
+      <AlertBox varient="dark" label="I'm from dark alert!" />
+      <AlertBox varient="light" label="I'm from light alert!" />
+    </div>
+  );
+};
+
+export default Alert;

--- a/apps/views/pages/index.module.css
+++ b/apps/views/pages/index.module.css
@@ -1,0 +1,5 @@
+@import "styles/common";
+
+.container a {
+  display: block;
+}

--- a/apps/views/pages/index.tsx
+++ b/apps/views/pages/index.tsx
@@ -4,13 +4,16 @@ import { Button } from "kbs-core";
 
 import { useIsomorphicLayoutEffect } from "kbs-utils";
 
+import stl from "./index.module.css";
+
 export default function Docs() {
   useIsomorphicLayoutEffect(() => {
     console.log("KBS docs page");
   }, []);
   return (
-    <div className="container my-5">
+    <div className={`container my-5 ${stl.container}`}>
       <h1>KBS Views</h1>
+      <Link href="/alert_box">Alert Component</Link>
       <Link href="/">Example Component Link</Link>
       <br />
       <br />

--- a/apps/views/styles/common.css
+++ b/apps/views/styles/common.css
@@ -1,0 +1,3 @@
+.dBlock {
+  display: block;
+}


### PR DESCRIPTION
Fixes #1 

### Add Alert Component

#### Props

```js
AlertBox.propTypes = {
  varient: PropTypes.string.isRequired,
  label: PropTypes.string,
  children: PropTypes.node,
}
```

#### Usage

##### Simple Usage
```js
<AlertBox varient="primary" label="Custom message" />
```

##### Children Usage
```js
<AlertBox varient="info">
  <p>
     You can use <Link href="#">example link(s)</Link> in alert box simply.
   </p>
</AlertBox>
```

### Component Preview 

<div align="center">
   <img src="https://user-images.githubusercontent.com/93012310/161210398-cef09b0e-8c35-4492-9fb9-330b83817577.png" 
    />
</div>
